### PR TITLE
(#33) Use selboolean instead of exec for SELinux

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -110,7 +110,7 @@ class misp::config inherits misp {
     subscribe => Exec['Directory permissions'],
   }
 
-  if $facts['os']['selinux']['enabled'] {
+  if fact('os.selinux.enabled') {
     selboolean { 'httpd redis connection':
       name       => 'httpd_can_network_connect',
       persistent => true,

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.19.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-vcsrepo",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -125,8 +125,7 @@ describe 'misp::config' do
         end
 
         it do
-          is_expected.to contain_exec('setsebool redis').
-            that_subscribes_to('File[/etc/opt/rh/rh-php56/php.d/99-redis.ini]')
+          is_expected.to_not contain_selboolean('httpd redis connection')
         end
 
         it do
@@ -141,7 +140,22 @@ describe 'misp::config' do
         end
 
         it do
-          is_expected.to contain_exec('setsebool redis').
+          is_expected.to_not contain_selboolean('httpd redis connection').
+            that_notifies('Service[httpd]')
+        end
+      end
+      context 'With SELinux enabled and webserver defined' do
+        let(:facts) do
+          data = facts
+          ((data[:os] ||= {})[:selinux] ||= {})[:enabled] = true
+          data
+        end
+        let(:pre_condition) do
+          'service{"httpd":}'
+        end
+
+        it do
+          is_expected.to contain_selboolean('httpd redis connection').
             that_notifies('Service[httpd]')
         end
       end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -125,7 +125,7 @@ describe 'misp::config' do
         end
 
         it do
-          is_expected.to_not contain_selboolean('httpd redis connection')
+          is_expected.not_to contain_selboolean('httpd redis connection')
         end
 
         it do
@@ -140,7 +140,7 @@ describe 'misp::config' do
         end
 
         it do
-          is_expected.to_not contain_selboolean('httpd redis connection').
+          is_expected.not_to contain_selboolean('httpd redis connection').
             that_notifies('Service[httpd]')
         end
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Replaces the exec type for setting SELinux booleans with Puppet's built-in selboolean type

#### This Pull Request (PR) fixes the following issues
Fixes #33
