### PR TITLE
Fix dependency collisions on non-present ensure

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -1,7 +1,7 @@
 
 class misp::dependencies inherits misp {
 
-  ensure_packages( [
+  [
     'gcc', # Needed for compiling Python modules
     'git', # Needed for pulling the MISP code and those for some dependencies
     'zip', 'mariadb',
@@ -11,12 +11,12 @@ class misp::dependencies inherits misp {
     'php-mbstring', #Required for Crypt_GPG
     'haveged',
     'sclo-php56-php-pecl-redis', # Redis connection from PHP
-    'php-pear-crypt-gpg', # Crypto GPG 
+    'php-pear-crypt-gpg', # Crypto GPG
     'python-magic', # Advance attachment handler
     'ssdeep', 'ssdeep-libs', 'ssdeep-devel', #For pydeep
-  ],
-    { 'ensure' => 'present' }
-  )
+  ].each |String $pkg| {
+    ensure_resource('package', $pkg)
+  }
 
   if $misp::manage_python {
     class { 'python' :
@@ -27,9 +27,7 @@ class misp::dependencies inherits misp {
   }
 
   if $misp::pymisp_rpm {
-    ensure_packages( ['pymisp'],
-      { 'ensure' => 'present' }
-    )
+    ensure_resource('package', 'pymisp')
   } else {
     python::pip { 'pymisp' :
       pkgname => 'pymisp',
@@ -37,8 +35,6 @@ class misp::dependencies inherits misp {
   }
 
   if $misp::lief {
-    ensure_packages( [$misp::lief_package_name],
-      { 'ensure' => 'present' }
-    )
+    ensure_resource('package', $misp::lief_package_name)
   }
 }

--- a/spec/classes/dependencies_spec.rb
+++ b/spec/classes/dependencies_spec.rb
@@ -35,5 +35,17 @@ describe 'misp::dependencies' do
       it { is_expected.to contain_package('ssdeep-libs') }
       it { is_expected.to contain_package('ssdeep-devel') }
     end
+
+    context "on #{os} with `ensure => latest` resources" do
+      let(:facts) do
+        facts
+      end
+
+      let(:pre_condition) do
+        'package { "git": ensure => latest }'
+      end
+
+      it { is_expected.to compile.with_all_deps }
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Plenty of other ensure values are used apart from 'present', causing
collisions if any of the dependencies are otherwise created using other
valid ensure values - 'installed', 'latest', etc.

#### This Pull Request (PR) fixes the following issues
Fixes #43