### PR TITLE
CI: fail dependency check if package set to absent

### DIFF
--- a/spec/classes/dependencies_spec.rb
+++ b/spec/classes/dependencies_spec.rb
@@ -47,5 +47,17 @@ describe 'misp::dependencies' do
 
       it { is_expected.to compile.with_all_deps }
     end
+
+    context "on #{os} with `ensure => absent` resources" do
+      let(:facts) do
+        facts
+      end
+
+      let(:pre_condition) do
+        'package { "git": ensure => absent }'
+      end
+
+      it { is_expected.not_to compile.with_all_deps }
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Add test for regression introduced by https://github.com/voxpupuli/puppet-misp/pull/44
Note: the CI is expected to fail (e.g. https://travis-ci.org/Feandil/puppet-misp/builds/501984931)
PR requested by @bastelfreak (https://github.com/voxpupuli/puppet-misp/pull/44#issuecomment-469420518)

#### This Pull Request (PR) fixes the following issues

n/a