### PR TITLE
Upgrade MISP to 2.4.111 and fix dependencies

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -9,7 +9,7 @@ class misp::dependencies inherits misp {
     'ssdeep', 'ssdeep-libs', 'ssdeep-devel', #For pydeep
 
     # PHP packages
-    "rh-${misp::php_version}", "rh-${misp::php_version}-php-fpm", "rh-${misp::php_version}-php-devel",
+    "rh-${misp::php_version}", "rh-${misp::php_version}-gd", "rh-${misp::php_version}-php-fpm", "rh-${misp::php_version}-php-devel",
     "rh-${misp::php_version}-php-mysqlnd", "rh-${misp::php_version}-php-mbstring", "rh-${misp::php_version}-php-pear",
     "rh-${misp::php_version}-php-xml", "rh-${misp::php_version}-php-bcmath",
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class misp (
   # MISP installation
   # # MISP repositories
   String $misp_git_repo = 'https://github.com/MISP/MISP.git',
-  String $misp_git_tag = 'v2.4.105',
+  String $misp_git_tag = 'v2.4.110',
   String $stix_git_repo = 'https://github.com/STIXProject/python-stix.git',
   String $stix_git_tag = 'v1.2.0.6',
   String $cybox_git_repo = 'https://github.com/CybOXProject/python-cybox.git',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class misp (
   # MISP installation
   # # MISP repositories
   String $misp_git_repo = 'https://github.com/MISP/MISP.git',
-  String $misp_git_tag = 'v2.4.110',
+  String $misp_git_tag = 'v2.4.111',
   String $stix_git_repo = 'https://github.com/STIXProject/python-stix.git',
   String $stix_git_tag = 'v1.2.0.6',
   String $cybox_git_repo = 'https://github.com/CybOXProject/python-cybox.git',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -86,9 +86,13 @@ class misp::install inherits misp {
       command => 'pip install zmq',
       unless  => 'pip freeze --all | /bin/grep zmq=';
 
-    'Install stix2 v1.1.1':
-      command => 'pip install stix2==1.1.1',
-      unless  => 'pip freeze --all | /bin/grep stix2==1.1.1';
+    'Install stix2 v1.1.2':
+      command => 'pip install stix2==1.1.2',
+      unless  => 'pip freeze --all | /bin/grep stix2==1.1.2';
+
+    'Install plyara':
+      command => 'pip install plyara',
+      unless  => 'pip freeze --all | /bin/grep plyara=';
   }
   if !$misp::pymisp_rpm {
     Exec <| title == 'Create MISP virtualenv' |>

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -187,7 +187,14 @@ describe 'misp::install' do
         end
 
         it do
-          is_expected.to contain_exec('Install stix2 v1.1.1').
+          is_expected.to contain_exec('Install stix2 v1.1.2').
+            with_path(%w[/var/www/MISP//venv/bin /usr/bin /bin]).
+            with_user('apache').
+            with_umask('0022')
+        end
+
+        it do
+          is_expected.to contain_exec('Install plyara').
             with_path(%w[/var/www/MISP//venv/bin /usr/bin /bin]).
             with_user('apache').
             with_umask('0022')


### PR DESCRIPTION
#### Pull Request (PR) description

Upgrades MISP to 2.4.111 - including security fixes and improvements.
This also adds gd to PHP 7.2, upgrades STIX2 to 1.1.2, and installs plyara, as required by the new MISP version.
