### PR TITLE
Upgrade MISP to 2.4.116

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,7 @@ class misp (
   Boolean $lief = false,
   Boolean $build_lief = false,
   $lief_package_name = '',
+  String $php_memory_limit = '2048M',
   # # Services
   $webservername = 'httpd',
   $redis_server = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class misp (
   # MISP installation
   # # MISP repositories
   String $misp_git_repo = 'https://github.com/MISP/MISP.git',
-  String $misp_git_tag = 'v2.4.111',
+  String $misp_git_tag = 'v2.4.116',
   String $stix_git_repo = 'https://github.com/STIXProject/python-stix.git',
   String $stix_git_tag = 'v1.2.0.6',
   String $cybox_git_repo = 'https://github.com/CybOXProject/python-cybox.git',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -342,6 +342,10 @@ class misp::install inherits misp {
     subscribe => File["/etc/opt/rh/rh-${misp::php_version}/php-fpm.d/timezone.ini"],
   }
 
+  file { "/etc/opt/rh/rh-${misp::php_version}/php-fpm.d/memory_limit.ini":
+    ensure  => file,
+    content => "[www]\nphp_admin_value[memory_limit] = ${misp::php_memory_limit}\n",
+  }
 
   ## File creation for managing workers
   #

--- a/spec/classes/dependencies_spec.rb
+++ b/spec/classes/dependencies_spec.rb
@@ -52,6 +52,7 @@ describe 'misp::dependencies' do
       it { is_expected.to contain_package('rh-php73-php-bcmath') }
       it { is_expected.to contain_package('sclo-php73-php-pecl-redis4') }
       it { is_expected.to contain_file('/etc/opt/rh/rh-php73/php-fpm.d/timezone.ini') }
+      it { is_expected.to contain_file('/etc/opt/rh/rh-php73/php-fpm.d/memory_limit.ini') }
       it { is_expected.to contain_file('/etc/opt/rh/rh-php73/php.d/99-timezone.ini') }
       it { is_expected.to contain_service('rh-php73-php-fpm') }
     end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -289,6 +289,12 @@ describe 'misp::install' do
         end
 
         it do
+          is_expected.to contain_file('/etc/opt/rh/rh-php72/php-fpm.d/memory_limit.ini').
+            with_ensure('file').
+            with_content("[www]\nphp_admin_value[memory_limit] = 2048M\n")
+        end
+
+        it do
           is_expected.to contain_file('/etc/opt/rh/rh-php72/php.d/99-timezone.ini').
             with_ensure('link').
             that_subscribes_to('File[/etc/opt/rh/rh-php72/php-fpm.d/timezone.ini]')


### PR DESCRIPTION
#### Pull Request (PR) description
An upgrade for MISP to the recently released 2.4.116 version.
This includes the fix for CVE-2019-16202 from 2.4.115 as well as a couple of fixes for issues that kept us from upgrading to 2.4.115 

MISP now recommends a 2GB memory limit for PHP, instead of the default of 512MB, so this also includes the Puppet code to be able to set that config.