### PR TITLE
Upgrade MISP to 2.4.118

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class misp (
   # MISP installation
   # # MISP repositories
   String $misp_git_repo = 'https://github.com/MISP/MISP.git',
-  String $misp_git_tag = 'v2.4.116',
+  String $misp_git_tag = 'v2.4.118',
   String $stix_git_repo = 'https://github.com/STIXProject/python-stix.git',
   String $stix_git_tag = 'v1.2.0.6',
   String $cybox_git_repo = 'https://github.com/CybOXProject/python-cybox.git',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -86,9 +86,9 @@ class misp::install inherits misp {
       command => 'pip install zmq',
       unless  => 'pip freeze --all | /bin/grep zmq=';
 
-    'Install stix2 v1.1.2':
-      command => 'pip install stix2==1.1.2',
-      unless  => 'pip freeze --all | /bin/grep stix2==1.1.2';
+    'Install stix2 v1.2.1':
+      command => 'pip install stix2==1.2.1',
+      unless  => 'pip freeze --all | /bin/grep stix2==1.2.1';
 
     'Install plyara':
       command => 'pip install plyara',

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -187,7 +187,7 @@ describe 'misp::install' do
         end
 
         it do
-          is_expected.to contain_exec('Install stix2 v1.1.2').
+          is_expected.to contain_exec('Install stix2 v1.2.1').
             with_path(%w[/var/www/MISP//venv/bin /usr/bin /bin]).
             with_user('apache').
             with_umask('0022')


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Upgrades MISP to version 2.4.118 - and STIX2 to 1.2.1 (>1.2.0 as required by the updates)

2.4.117 comes with a bunch of quite frankly massive performance improvements, and 2.4.118 provides some work towards automated database schema management in preparation for 2.4.119.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
