### PR TITLE
chore: Replace build badges to use GitHub Actions instead of Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MISP MODULE
 
-[![Build Status](https://travis-ci.org/voxpupuli/puppet-misp.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-misp)
+![Build Status](https://github.com/voxpupuli/puppet-misp/actions/workflows/ci.yml/badge.svg?branch=master)
 [![Code Coverage](https://coveralls.io/repos/github/voxpupuli/puppet-misp/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet-misp)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/misp.svg)](https://forge.puppetlabs.com/puppet/misp)
 [![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/misp.svg)](https://forge.puppetlabs.com/puppet/misp)


### PR DESCRIPTION
Refs: https://github.com/voxpupuli/modulesync_config/issues/1012, https://github.com/voxpupuli/plumbing/issues/84
